### PR TITLE
fix(resume): prevent orphaned section headings at page break

### DIFF
--- a/src/components/resume/shared/page-section.tsx
+++ b/src/components/resume/shared/page-section.tsx
@@ -21,7 +21,9 @@ export function PageSection<T extends SectionType>({ type, className, children }
 
   return (
     <section className={cn(`page-section page-section-${type}`, className)}>
-      <h6 className="mb-1.5 text-(--page-primary-color) print:break-after-avoid">{section.title || getSectionTitle(type)}</h6>
+      <h6 className="mb-1.5 text-(--page-primary-color) print:break-after-avoid">
+        {section.title || getSectionTitle(type)}
+      </h6>
 
       <div
         className="section-content grid gap-x-(--page-gap-x) gap-y-(--page-gap-y)"

--- a/src/components/resume/shared/page-section.tsx
+++ b/src/components/resume/shared/page-section.tsx
@@ -21,7 +21,7 @@ export function PageSection<T extends SectionType>({ type, className, children }
 
   return (
     <section className={cn(`page-section page-section-${type}`, className)}>
-      <h6 className="mb-1.5 text-(--page-primary-color)">{section.title || getSectionTitle(type)}</h6>
+      <h6 className="mb-1.5 text-(--page-primary-color) print:break-after-avoid">{section.title || getSectionTitle(type)}</h6>
 
       <div
         className="section-content grid gap-x-(--page-gap-x) gap-y-(--page-gap-y)"


### PR DESCRIPTION
Add `print:break-after-avoid` to section headings in `page-section.tsx` so Chromium prefers to break *before* the heading rather than stranding it alone at the bottom of a page while all items render on the next.

Items already carry `print:break-inside-avoid` (line 31), but there was no rule keeping the heading together with the first item. This single Tailwind utility mirrors LaTeX's `\widowpenalty` / `\clubpenalty` behavior for section headings.

Fixes amruthpillai/reactive-resume#2839